### PR TITLE
fix: release build crash, rotated Euler angles, distance range (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.2.3
+
+### Fixed
+- **Release APK crash (R8/ProGuard)**: R8 class-merging optimization broke MediaPipe's JNI native library loading via stack inspection, causing `ExceptionInInitializerError` at runtime. Added `-dontoptimize` and explicit `-keep` rules for MediaPipe, protobuf, and plugin classes in consumer ProGuard rules.
+- **Euler angles rotated 90°**: Camera sensor orientation (`sensorOrientation=270` on most front cameras) was sent from Dart but never applied on the native side. MediaPipe computed angles in raw sensor coordinates, causing pitch/yaw/roll to be misassigned (e.g. "head nod up" fired when turning right). Now compensated via `correctAnglesForRotation()` after Euler extraction.
+- **Distance "ok" range too narrow**: Default thresholds (`minDistanceRatio=0.20`, `maxDistanceRatio=0.60`) required holding the device uncomfortably close. Relaxed to `0.05`/`0.40` for comfortable arm-length usage.
+
+---
+
 ## 0.2.2
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See [doc/architecture.md](doc/architecture.md) for full details.
 
 ## Status
 
-> **v0.2.0** — Full end-to-end face gesture detection on Android. Pass a `CameraController` and receive callbacks.
+> **v0.2.3** — Full end-to-end face gesture detection on Android with release build support.
 
 - [x] Data model with 52 blendshapes, landmarks, pose angles
 - [x] Platform interface (MethodChannel + EventChannel + processFrame)
@@ -80,4 +80,5 @@ See [doc/architecture.md](doc/architecture.md) for full details.
 - [x] Native Android — MediaPipe Face Landmarker (LIVE_STREAM + GPU delegate)
 - [x] Camera integration — `cameraController` parameter wires the full pipeline
 - [x] Example app — live camera preview with real-time gesture detection
+- [x] Release build — ProGuard rules, sensor orientation compensation
 - [ ] Native iOS

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -34,6 +34,7 @@ configure<com.android.build.gradle.LibraryExtension> {
     defaultConfig {
         minSdk = 24
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
     }
 }
 

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,24 @@
+# face_gesture_detector — ProGuard/R8 consumer rules
+# These rules are automatically applied to any app that depends on this plugin.
+
+# Disable R8 optimization — class merging breaks MediaPipe's
+# stack-based native library loader (Graph.<clinit> uses stack inspection)
+-dontoptimize
+
+# Keep MediaPipe classes (JNI, reflection, protobuf-lite)
+-keep class com.google.mediapipe.** { *; }
+-keepclassmembers class com.google.mediapipe.** { *; }
+-dontwarn com.google.mediapipe.**
+
+# MediaPipe depends on protobuf-lite
+-keep class com.google.protobuf.** { *; }
+-dontwarn com.google.protobuf.**
+
+# Keep plugin classes (EventChannel, MethodChannel handlers)
+-keep class dev.macss.face_gesture_detector.** { *; }
+
+# AutoValue annotation-processing classes (compile-time only, not needed at runtime)
+-dontwarn javax.annotation.processing.**
+-dontwarn javax.lang.model.**
+-dontwarn autovalue.shaded.**
+-dontwarn com.google.auto.**

--- a/android/src/main/kotlin/dev/macss/face_gesture_detector/FaceGestureDetectorPlugin.kt
+++ b/android/src/main/kotlin/dev/macss/face_gesture_detector/FaceGestureDetectorPlugin.kt
@@ -96,8 +96,9 @@ class FaceGestureDetectorPlugin : FlutterPlugin, MethodCallHandler {
         }
 
         val timestamp = call.argument<Long>("timestamp") ?: System.currentTimeMillis()
+        val rotation = call.argument<Int>("rotation") ?: 0
 
-        frameBuffer.deposit(RawFrame(bytes, width, height, timestamp))
+        frameBuffer.deposit(RawFrame(bytes, width, height, timestamp, rotation))
         scheduleProcessing()
 
         // Return immediately — processing happens on the background executor.
@@ -109,7 +110,7 @@ class FaceGestureDetectorPlugin : FlutterPlugin, MethodCallHandler {
         backgroundExecutor.submit {
             val rawFrame = frameBuffer.acquire() ?: return@submit
             val mpImage = FrameDecoder.decode(rawFrame.bytes, rawFrame.width, rawFrame.height)
-            engine?.detectAsync(mpImage, rawFrame.timestampMs)
+            engine?.detectAsync(mpImage, rawFrame.timestampMs, rawFrame.rotation)
         }
     }
 
@@ -131,4 +132,5 @@ private data class RawFrame(
     val width: Int,
     val height: Int,
     val timestampMs: Long,
+    val rotation: Int,
 )

--- a/android/src/main/kotlin/dev/macss/face_gesture_detector/FaceLandmarkerEngine.kt
+++ b/android/src/main/kotlin/dev/macss/face_gesture_detector/FaceLandmarkerEngine.kt
@@ -28,6 +28,7 @@ class FaceLandmarkerEngine(
 
     private var landmarker: FaceLandmarker? = null
     private var includeLandmarks = false
+    @Volatile private var currentRotation: Int = 0
 
     /**
      * Initializes the FaceLandmarker with the given detection options.
@@ -68,7 +69,8 @@ class FaceLandmarkerEngine(
      * construction. If a previous frame is still being processed, MediaPipe
      * drops the new one automatically (LIVE_STREAM mode behavior).
      */
-    fun detectAsync(image: MPImage, timestampMs: Long) {
+    fun detectAsync(image: MPImage, timestampMs: Long, rotation: Int = 0) {
+        currentRotation = rotation
         landmarker?.detectAsync(image, timestampMs)
     }
 
@@ -133,7 +135,7 @@ class FaceLandmarkerEngine(
         val maxY = ys.max()
 
         // Euler angles from the 4×4 transformation matrix
-        val (pitch, yaw, roll) = if (matrix != null) {
+        val (rawPitch, rawYaw, rawRoll) = if (matrix != null) {
             // MediaPipe Matrix stores 16 floats in row-major order.
             // EulerAngleCalculator expects column-major, so we transpose.
             val flatMatrix = FloatArray(16)
@@ -146,6 +148,13 @@ class FaceLandmarkerEngine(
         } else {
             Triple(0.0, 0.0, 0.0)
         }
+
+        // MediaPipe computes angles in the raw image coordinate system.
+        // Compensate for camera sensor orientation so angles are relative
+        // to the device's portrait orientation.
+        val (pitch, yaw, roll) = correctAnglesForRotation(
+            rawPitch, rawYaw, rawRoll, currentRotation,
+        )
 
         // Blendshape map: name → score
         val blendshapeMap = mutableMapOf<String, Double>()
@@ -196,5 +205,31 @@ class FaceLandmarkerEngine(
                 "sharpness" to 100.0, // TODO M3.7: compute Laplacian variance
             ),
         )
+    }
+
+    /**
+     * Transforms Euler angles from raw-image coordinates to device-portrait
+     * coordinates, compensating for camera sensor orientation.
+     *
+     * The camera sensor produces frames rotated [sensorOrientation]° CW from
+     * portrait. The image content is therefore (360 − sensorOrientation)° CW
+     * from upright. Pitch and yaw (rotations around X/Y) are remapped using
+     * the 2-D rotation inverse, and the roll offset is subtracted.
+     */
+    private fun correctAnglesForRotation(
+        pitch: Double, yaw: Double, roll: Double, sensorOrientation: Int,
+    ): Triple<Double, Double, Double> {
+        val alpha = ((360 - sensorOrientation) % 360 + 360) % 360
+        val (cp, cy, cr) = when (alpha) {
+            90  -> Triple(-yaw, -pitch, roll - 90.0)
+            180 -> Triple(-pitch, -yaw, roll - 180.0)
+            270 -> Triple(yaw, pitch, roll - 270.0)
+            else -> Triple(pitch, yaw, roll)
+        }
+        // Normalise roll to [−180, 180]
+        var nr = cr % 360.0
+        if (nr > 180.0) nr -= 360.0
+        if (nr < -180.0) nr += 360.0
+        return Triple(cp, cy, nr)
     }
 }

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -35,6 +35,10 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 }

--- a/example/android/app/proguard-rules.pro
+++ b/example/android/app/proguard-rules.pro
@@ -1,0 +1,26 @@
+# Disable R8 optimization (class merging breaks MediaPipe's
+# stack-based native library loader)
+-dontoptimize
+
+# Keep all MediaPipe classes (JNI, reflection, native library loading)
+-keep class com.google.mediapipe.** { *; }
+-keepclassmembers class com.google.mediapipe.** { *; }
+-dontwarn com.google.mediapipe.**
+
+# Keep protobuf (used by MediaPipe)
+-keep class com.google.protobuf.** { *; }
+-dontwarn com.google.protobuf.**
+
+# Keep ALL google classes to prevent R8 class-merging that breaks
+# MediaPipe's stack-based native library loader
+-keep class com.google.** { *; }
+-dontwarn com.google.**
+
+# Keep plugin classes
+-keep class dev.macss.face_gesture_detector.** { *; }
+
+# AutoValue compile-time only
+-dontwarn javax.annotation.processing.**
+-dontwarn javax.lang.model.**
+-dontwarn autovalue.shaded.**
+-dontwarn com.google.auto.**

--- a/example/integration_test/plugin_integration_test.dart
+++ b/example/integration_test/plugin_integration_test.dart
@@ -132,70 +132,69 @@ void main() {
       expect(framesProcessed, greaterThanOrEqualTo(3));
     });
 
-    testWidgets(
-      'faceFrameStream emits data from real camera',
-      (WidgetTester tester) async {
-        final cameras = await availableCameras();
-        if (cameras.isEmpty) return;
+    testWidgets('faceFrameStream emits data from real camera', (
+      WidgetTester tester,
+    ) async {
+      final cameras = await availableCameras();
+      if (cameras.isEmpty) return;
 
-        final front = cameras.firstWhere(
-          (c) => c.lensDirection == CameraLensDirection.front,
-          orElse: () => cameras.first,
+      final front = cameras.firstWhere(
+        (c) => c.lensDirection == CameraLensDirection.front,
+        orElse: () => cameras.first,
+      );
+      final controller = CameraController(
+        front,
+        ResolutionPreset.low,
+        enableAudio: false,
+        imageFormatGroup: ImageFormatGroup.nv21,
+      );
+
+      await controller.initialize();
+
+      final platform = FaceGestureDetectorPlatform.instance;
+      final options = FaceDetectionOptions.fromConfiguration(
+        FaceGestureConfiguration(),
+      );
+      await platform.startDetection(options);
+
+      final received = <Map<String, dynamic>>[];
+      final sub = platform.faceFrameStream.listen(received.add);
+
+      await controller.startImageStream((CameraImage image) async {
+        final totalBytes = image.planes.fold<int>(
+          0,
+          (sum, plane) => sum + plane.bytes.length,
         );
-        final controller = CameraController(
-          front,
-          ResolutionPreset.low,
-          enableAudio: false,
-          imageFormatGroup: ImageFormatGroup.nv21,
+        final buffer = Uint8List(totalBytes);
+        var offset = 0;
+        for (final plane in image.planes) {
+          buffer.setRange(offset, offset + plane.bytes.length, plane.bytes);
+          offset += plane.bytes.length;
+        }
+
+        await platform.processFrame(
+          FrameData(
+            bytes: buffer,
+            width: image.width,
+            height: image.height,
+            rotation: controller.description.sensorOrientation,
+          ),
         );
+      });
 
-        await controller.initialize();
+      // Give the pipeline time to produce results.
+      await Future<void>.delayed(const Duration(seconds: 5));
 
-        final platform = FaceGestureDetectorPlatform.instance;
-        final options = FaceDetectionOptions.fromConfiguration(
-          FaceGestureConfiguration(),
-        );
-        await platform.startDetection(options);
+      await controller.stopImageStream();
+      await Future<void>.delayed(const Duration(seconds: 1));
+      await sub.cancel();
+      await platform.stopDetection();
+      await controller.dispose();
 
-        final received = <Map<String, dynamic>>[];
-        final sub = platform.faceFrameStream.listen(received.add);
-
-        await controller.startImageStream((CameraImage image) async {
-          final totalBytes = image.planes.fold<int>(
-            0,
-            (sum, plane) => sum + plane.bytes.length,
-          );
-          final buffer = Uint8List(totalBytes);
-          var offset = 0;
-          for (final plane in image.planes) {
-            buffer.setRange(offset, offset + plane.bytes.length, plane.bytes);
-            offset += plane.bytes.length;
-          }
-
-          await platform.processFrame(
-            FrameData(
-              bytes: buffer,
-              width: image.width,
-              height: image.height,
-              rotation: controller.description.sensorOrientation,
-            ),
-          );
-        });
-
-        // Give the pipeline time to produce results.
-        await Future<void>.delayed(const Duration(seconds: 5));
-
-        await controller.stopImageStream();
-        await Future<void>.delayed(const Duration(seconds: 1));
-        await sub.cancel();
-        await platform.stopDetection();
-        await controller.dispose();
-
-        // Accept ≥0 to avoid flakiness — whether face data arrives depends
-        // on what the camera sees. The key assertion is: no crash.
-        expect(received, isA<List<Map<String, dynamic>>>());
-      },
-    );
+      // Accept ≥0 to avoid flakiness — whether face data arrives depends
+      // on what the camera sees. The key assertion is: no crash.
+      expect(received, isA<List<Map<String, dynamic>>>());
+    });
   });
 
   // ── Platform API tests (no camera needed) ────────────────────────

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -99,7 +99,8 @@ class _FaceDetectorDemoState extends State<FaceDetectorDemo>
   }
 
   void _addEvent(String event) {
-    final entry = '${DateTime.now().toIso8601String().substring(11, 19)} $event';
+    final entry =
+        '${DateTime.now().toIso8601String().substring(11, 19)} $event';
     debugPrint('[FaceGesture] $entry');
     setState(() {
       _events.insert(0, entry);
@@ -167,33 +168,31 @@ class _FaceDetectorDemoState extends State<FaceDetectorDemo>
       onFaceDetected: (details) {
         if (!_hasFace) {
           _hasFace = true;
-          _addEvent(
-            'Face detected (${(details.confidence * 100).toInt()}%)',
-          );
+          _addEvent('Face detected (${(details.confidence * 100).toInt()}%)');
         }
       },
       onFaceLost: () {
         _hasFace = false;
         _addEvent('Face lost');
       },
-      onBlinkDetected: (details) => _addEvent(
-        'Blink (${details.blinkDuration.inMilliseconds}ms)',
-      ),
+      onBlinkDetected: (details) =>
+          _addEvent('Blink (${details.blinkDuration.inMilliseconds}ms)'),
       onSmileDetected: (details) => _addEvent(
         'Smile (intensity: ${details.intensity.toStringAsFixed(2)})',
       ),
-      onHeadTurnDetected: (details) =>
-          _addEvent('Head turn ${details.direction.name}'),
-      onHeadNodDetected: (details) =>
-          _addEvent('Head nod ${details.direction.name}'),
-      onBrowRaised: (details) => _addEvent(
-        'Brow raised (${details.intensity.toStringAsFixed(2)})',
+      onHeadTurnDetected: (details) => _addEvent(
+        'Head turn ${details.direction.name} (yaw=${details.yawAngle.toStringAsFixed(1)})',
       ),
-      onMouthOpened: (details) => _addEvent(
-        'Mouth open (${details.openness.toStringAsFixed(2)})',
+      onHeadNodDetected: (details) => _addEvent(
+        'Head nod ${details.direction.name} (pitch=${details.pitchAngle.toStringAsFixed(1)})',
       ),
-      onPoseChanged: (details) =>
-          _addEvent('Pose: frontal=${details.isFrontal}'),
+      onBrowRaised: (details) =>
+          _addEvent('Brow raised (${details.intensity.toStringAsFixed(2)})'),
+      onMouthOpened: (details) =>
+          _addEvent('Mouth open (${details.openness.toStringAsFixed(2)})'),
+      onPoseChanged: (details) => _addEvent(
+        'Pose: p=${details.angles.pitch.toStringAsFixed(1)} y=${details.angles.yaw.toStringAsFixed(1)} r=${details.angles.roll.toStringAsFixed(1)}',
+      ),
       onDistanceChanged: (details) =>
           _addEvent('Distance: ${details.category.name}'),
       child: CameraPreview(camera),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -95,7 +95,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.1"
+    version: "0.2.2"
   fake_async:
     dependency: transitive
     description:

--- a/lib/src/configuration/face_gesture_configuration.dart
+++ b/lib/src/configuration/face_gesture_configuration.dart
@@ -54,8 +54,8 @@ class FaceGestureConfiguration {
 
   const FaceGestureConfiguration({
     this.faceDetectionConfidence = 0.5,
-    this.minDistanceRatio = 0.20,
-    this.maxDistanceRatio = 0.60,
+    this.minDistanceRatio = 0.05,
+    this.maxDistanceRatio = 0.40,
     this.headTurnYawThreshold = 25.0,
     this.headNodPitchThreshold = 20.0,
     this.blinkThreshold = 0.35,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: face_gesture_detector
 description: "A widget that detects face gestures."
-version: 0.2.2
+version: 0.2.3
 repository: https://github.com/macss-dev/face_gesture_detector
 
 environment:

--- a/test/model/face_gesture_configuration_test.dart
+++ b/test/model/face_gesture_configuration_test.dart
@@ -10,8 +10,8 @@ void main() {
       expect(config.faceDetectionConfidence, 0.5);
 
       // Distance
-      expect(config.minDistanceRatio, 0.20);
-      expect(config.maxDistanceRatio, 0.60);
+      expect(config.minDistanceRatio, 0.05);
+      expect(config.maxDistanceRatio, 0.40);
 
       // Gesture thresholds
       expect(config.headTurnYawThreshold, 25.0);
@@ -45,7 +45,7 @@ void main() {
       expect(config.sustainedGestureDuration, Duration(milliseconds: 200));
 
       // Non-overridden values remain at defaults
-      expect(config.minDistanceRatio, 0.20);
+      expect(config.minDistanceRatio, 0.05);
       expect(config.headTurnYawThreshold, 25.0);
     });
   });

--- a/test/recognizer/quality_gate_recognizer_test.dart
+++ b/test/recognizer/quality_gate_recognizer_test.dart
@@ -67,9 +67,8 @@ void main() {
     );
 
     test('fires onDistanceChanged with tooClose for large bounding box', () {
-      // Very large face → too close. Ratio = (800*1200) / (1080*1920) ≈ 0.46
-      // With defaults: maxDistanceRatio = 0.60, this is still optimal.
-      // Need even bigger: (900*1500) / (1080*1920) ≈ 0.65
+      // Very large face → too close. Ratio = (900*1500) / (1080*1920) ≈ 0.65
+      // With defaults: maxDistanceRatio = 0.40, this exceeds it → tooClose.
       recognizer.addFaceFrame(_frame(bboxWidth: 900, bboxHeight: 1500));
 
       expect(distanceEvents, hasLength(1));
@@ -77,10 +76,8 @@ void main() {
     });
 
     test('fires onDistanceChanged with optimal for medium bounding box', () {
-      // Medium face. Ratio = (400*500) / (1080*1920) ≈ 0.096
-      // That's < 0.20 → tooFar. Let's use bigger: (500*700)/(1080*1920) = 0.169 → tooFar
-      // Need:  0.20 * 1080 * 1920 = 414,720; sqrt ≈ 644. Use 650x650:
-      // (650*650)/(1080*1920) = 422500/2073600 = 0.204 → optimal
+      // Medium face. Ratio = (650*650) / (1080*1920) = 422500/2073600 ≈ 0.204
+      // With defaults: minDistanceRatio = 0.05, maxDistanceRatio = 0.40 → optimal.
       recognizer.addFaceFrame(_frame(bboxWidth: 650, bboxHeight: 650));
 
       expect(distanceEvents, hasLength(1));

--- a/test/widget/raw_face_gesture_detector_test.dart
+++ b/test/widget/raw_face_gesture_detector_test.dart
@@ -220,8 +220,9 @@ void main() {
       mockPlatform.dispose();
     });
 
-    testWidgets('calls startDetection on init when cameraController is null',
-        (tester) async {
+    testWidgets('calls startDetection on init when cameraController is null', (
+      tester,
+    ) async {
       // Without cameraController, no startDetection should be called.
       await tester.pumpWidget(
         RawFaceGestureDetector(
@@ -234,8 +235,9 @@ void main() {
       expect(mockPlatform.startDetectionCalled, isFalse);
     });
 
-    testWidgets('dispatches FaceFrame from faceFrameStream to recognizers',
-        (tester) async {
+    testWidgets('dispatches FaceFrame from faceFrameStream to recognizers', (
+      tester,
+    ) async {
       final factory = _TestRecognizerFactory(config);
 
       await tester.pumpWidget(
@@ -259,8 +261,9 @@ void main() {
       expect(factory.lastCreated!.receivedFrames.first.isFaceDetected, isTrue);
     });
 
-    testWidgets('calls stopDetection on dispose when pipeline was null',
-        (tester) async {
+    testWidgets('calls stopDetection on dispose when pipeline was null', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         RawFaceGestureDetector(
           configuration: config,


### PR DESCRIPTION
## Summary

Fixes three runtime bugs discovered during release build testing on a physical device (Samsung SM-A045M, Android 14).

Closes #5

## Changes

### 1. ProGuard rules for R8 compatibility (`8688066`)
- R8 class-merging broke MediaPipe's JNI native library loading via stack inspection (`Graph.<clinit>`)
- Added `consumer-rules.pro` with `-dontoptimize` and `-keep` rules for MediaPipe, protobuf, and plugin classes
- Added matching `proguard-rules.pro` for example app
- APK size impact: ~1.2MB (39.5 → 40.7MB)

### 2. Euler angle sensor orientation compensation (`77036c8`)
- Front camera `sensorOrientation=270` means frames are rotated 90° from portrait
- MediaPipe computed angles in raw sensor coordinates → pitch/yaw/roll were misassigned
- `ImageProcessingOptions.setRotationDegrees()` has no effect in LIVE_STREAM mode
- Solution: post-computation compensation via `correctAnglesForRotation()` that remaps angles based on 0°/90°/180°/270° sensor orientation

### 3. Distance thresholds relaxed (`23f3fb9`)
- Default `minDistanceRatio=0.20, maxDistanceRatio=0.60` required uncomfortably close distance
- Relaxed to `0.05/0.40` for comfortable arm-length usage

### 4. Example app & tests (`273e4b3`)
- Example app shows angle diagnostic values in event log
- Updated configuration tests and quality gate tests for new defaults

### 5. Version bump to 0.2.3 (`53e1a44`)
- CHANGELOG, README, pubspec.yaml updated

## Testing

- 127/127 Dart unit tests passing
- Release APK verified on device (no crash)
- Head turn left/right verified correct
- Head nod up/down pending final verification after pitch sign fix
- Distance "optimal" at comfortable arm-length